### PR TITLE
Add 0xc0 Line for Realtek ALC256 to restore some bass loss through headphones

### DIFF
--- a/ComboJack_Source/Combo Jack/hda-verb.m
+++ b/ComboJack_Source/Combo Jack/hda-verb.m
@@ -738,6 +738,7 @@ void alcInit()
             VerbCommand(HDA_VERB(0x19, AC_VERB_SET_PIN_WIDGET_CONTROL, 0x24));
             VerbCommand(HDA_VERB(0x1a, AC_VERB_SET_PIN_WIDGET_CONTROL, 0x20));
             VerbCommand(HDA_VERB(0x21, AC_VERB_SET_UNSOLICITED_ENABLE, 0x83));
+            VerbCommand(HDA_VERB(0x21, AC_VERB_SET_PIN_WIDGET_CONTROL, 0xC0));
             break;
         case 0x10ec0298:
             VerbCommand(HDA_VERB(0x18, AC_VERB_SET_PIN_WIDGET_CONTROL, 0x22));


### PR DESCRIPTION
My codec through Linux has 0xC0 defined for 0x21 node. I've noticed with my codec with testing that without this line I am missing some bass when I play media through the headphone jack and sound has too much treble. This restores the bass and audio still sounds good without noise.